### PR TITLE
Fix fedora exit 1 from hostnamectl

### DIFF
--- a/resources/hostname.rb
+++ b/resources/hostname.rb
@@ -80,7 +80,7 @@ action :set do
         # this must come before other methods like /etc/hostname and /etc/sysconfig/network
         execute "hostnamectl set-hostname #{new_resource.hostname}" do
           notifies :reload, "ohai[reload hostname]"
-          not_if { shell_out!("hostnamectl status").stdout =~ /Static hostname:\s+#{new_resource.hostname}/ }
+          not_if { shell_out!("hostnamectl status", { :returns => [0, 1] }).stdout =~ /Static hostname:\s+#{new_resource.hostname}/ }
         end
       when ::File.exist?("/etc/hostname")
         # debian family uses /etc/hostname


### PR DESCRIPTION
apparently hostnamectl status can exit 1 even though it works
