### PR TITLE
Add supported platforms from README to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,3 +11,8 @@ issues_url       "https://github.com/lamont-cookbooks/chef_hostname/issues" if r
 depends "compat_resource"
 
 chef_version "~> 12.1" if respond_to?(:chef_version)
+
+%w{redhat centos scientific oracle fedora ubuntu debian suse freebsd mac_os_x
+   solaris gentoo arch nexus}.each do |platform|
+  supports platform
+end


### PR DESCRIPTION
Adds a buncha icons to Supermarket entry and makes it appear in platform-specific searches.

<img width="327" alt="screen shot 2016-04-05 at 4 18 28 pm" src="https://cloud.githubusercontent.com/assets/517302/14296853/0e0ca72a-fb4a-11e5-9bf2-ce083f6ce941.png">
