### PR TITLE
Fix duplicate HOSTNAME= on centos 6

### DIFF
--- a/resources/hostname.rb
+++ b/resources/hostname.rb
@@ -97,7 +97,7 @@ action :set do
         end
       when ::File.exist?("/etc/sysconfig/network")
         # older non-systemd RHEL/Fedora derived
-        append_replacing_matching_lines("/etc/sysconfig/network", /^HOSTNAME\s+=/, "HOSTNAME=#{new_resource.hostname}")
+        append_replacing_matching_lines("/etc/sysconfig/network", /^HOSTNAME\s*=/, "HOSTNAME=#{new_resource.hostname}")
       when ::File.exist?("/etc/HOSTNAME")
         # SuSE/OpenSUSE uses /etc/HOSTNAME
         file "/etc/HOSTNAME" do


### PR DESCRIPTION
### Description

Changes the regex when looking for HOSTNAME= in /etc/sysconfig/network to not require a space.
### Issues Resolved

Fixes https://github.com/chef-cookbooks/chef_hostname/issues/16
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
