### PR TITLE
Fixed windows hostname issue

### DIFF
--- a/resources/hostname.rb
+++ b/resources/hostname.rb
@@ -179,7 +179,7 @@ action :set do
     powershell_script "set hostname" do
       code <<-EOH
         $sysInfo = Get-WmiObject -Class Win32_ComputerSystem
-        $sysInfo.Rename(#{new_resource.hostname})
+        $sysInfo.Rename("#{new_resource.hostname}")
       EOH
       not_if { Socket.gethostbyname(Socket.gethostname).first == new_resource.hostname }
     end


### PR DESCRIPTION
### Description

Added double quotes in the variable that changes the hostname in windows, which is not currently working.
### Issues Resolved

None.
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable 
  - No need
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
