### PR TITLE
Require Chef 12.5+ and remove compat_resource dependency

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -14,15 +14,7 @@ platforms:
     run_command: /usr/lib/systemd/systemd
     provision_command:
       - /bin/yum install -y initscripts net-tools wget
-- name: ubuntu-12.04
-  driver:
-    image: ubuntu-upstart:12.04
-    platform: ubuntu
-    disable_upstart: false
-    run_command: /sbin/init
-    provision_command:
-      - /usr/bin/apt-get update
-      - /usr/bin/apt-get install apt-transport-https net-tools -y
+
 - name: ubuntu-14.04
   driver:
     image: ubuntu-upstart:14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,24 +7,18 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: "12.1.2"
 
 platforms:
-  - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: ubuntu-16.04
-  - name: centos-5.11
-  - name: centos-6.7
-  - name: centos-7.2
-  - name: freebsd-9.3
+  - name: centos-6.8
+  - name: centos-7.3
   - name: freebsd-10.2
-  - name: fedora-21
-  - name: fedora-22
-  - name: fedora-23
-  - name: debian-8.4
-  - name: debian-7.10
-  - name: debian-6.0.10
-  - name: opensuse-13.2
+  - name: freebsd-11.0
+  - name: fedora-25
+  - name: debian-8.6
+  - name: debian-7.11
+  - name: opensuse-leap-42.2
   - name: windows-2008r2
     driver_config:
       box: chef/windows-server-2008r2-standard

--- a/README.md
+++ b/README.md
@@ -2,25 +2,26 @@
 
 Sets the node's hostname
 
-* resource-driven cookbook
-* supports FQDNs as hostnames
-* persists after a reboot
-* reloads ohai
-* runs at compile-time (no need to use lazy)
-* fixes up /etc/hosts so node["fqdn"] works
-* runs nearly everywhere
-* supports hostnamectl from systemd
-* not tied to any other sysctl/etc-hosts cookbook dependecies
+- resource-driven cookbook
+- supports FQDNs as hostnames
+- persists after a reboot
+- reloads ohai
+- runs at compile-time (no need to use lazy)
+- fixes up /etc/hosts so node["fqdn"] works
+- runs nearly everywhere
+- supports hostnamectl from systemd
+- not tied to any other sysctl/etc-hosts cookbook dependecies
 
 ## Motivation
 
-* Make strong guarantees that `node["fqdn"]` in other recipes "just works"
-* No need to `lazy { node["fqdn"] }`
-* Be very portable
+- Make strong guarantees that `node["fqdn"]` in other recipes "just works"
+- No need to `lazy { node["fqdn"] }`
+- Be very portable
 
 ## Requirements
 
 ## Platforms
+
 - Ubuntu/Debian (and derivatives like Mint/Raspbian)
 - RHEL/CentOS/Scientific/Oracle/Fedora (and derivatives like Pidora)
 - OpenSUSE/SLES
@@ -33,15 +34,15 @@ Sets the node's hostname
 - Cisco Nexus
 - Windows <-- currently a bit of a lie
 
-Because of the way that this cookbook "Duck Types" the operating system, many systems that are not listed above
-have a decent chance of working out of the box provided that they implement a common pattern.
+Because of the way that this cookbook "Duck Types" the operating system, many systems that are not listed above have a decent chance of working out of the box provided that they implement a common pattern.
 
 ### Chef
-- Chef 12.1+
+
+- Chef 12.5+
 
 ### Cookbooks
-- compat_resource
 
+- none
 
 ## Custom Resources
 
@@ -54,11 +55,12 @@ hostname Sets the hostname, ensures that reboot will preserve the hostname, re-r
 ### Properties
 
 - hostname: hostname to set
-- compile_time:  defaults to running at compile time, set to false to disable
+- compile_time: defaults to running at compile time, set to false to disable
 
 ### Chefspec / Testing
 
 The action to be used in Chefspec/tests is "set" for exmaple:
+
 ```ruby
       it 'checks if hostname is being set' do
         expect(chef_run).to set_hostname('your.hostname.com')
@@ -106,8 +108,7 @@ file "/etc/issue" do
 end
 ```
 
-The hostname resource will drop a line into /etc/hosts so that the `node["fqdn"]` can be resolved correctly, and will re-trigger ohai.  The default is
-to use the node["ipaddress"]` value for the ipaddress on the /etc/hosts line.  In order to override it:
+The hostname resource will drop a line into /etc/hosts so that the `node["fqdn"]` can be resolved correctly, and will re-trigger ohai. The default is to use the node["ipaddress"]` value for the ipaddress on the /etc/hosts line. In order to override it:
 
 ```ruby
 hostname node["cloud"]["public_hostname"]
@@ -115,8 +116,7 @@ hostname node["cloud"]["public_hostname"]
 end
 ```
 
-In order to override the editing of the /etc/hosts file pass nil for the ipaddress (note that if you edit the /etc/hosts file you will be responsible
-for also reloading the ohai plugin and you will want to do both at compile-time yourself in order for `node["fqdn"]` to resolve)
+In order to override the editing of the /etc/hosts file pass nil for the ipaddress (note that if you edit the /etc/hosts file you will be responsible for also reloading the ohai plugin and you will want to do both at compile-time yourself in order for `node["fqdn"]` to resolve)
 
 ```ruby
 hostname node.name
@@ -135,16 +135,16 @@ end
 
 ## Notes
 
-There are no recipes in this cookbook, the resource is meant to be used in your own custom recipes.  There are no attributes in this cookbook,
-you can drive the resource off of whatever attribute(s) you like.
+There are no recipes in this cookbook, the resource is meant to be used in your own custom recipes. There are no attributes in this cookbook, you can drive the resource off of whatever attribute(s) you like.
 
 Docker container hostnames do not persist after restarts due to limitations of docker.
 
 ## TODO
+
 - fix setting node['fqdn'] correctly on windows
 - aix
 - xenserver (probably already supported via RHEL)
-- test:  exherbo, alpine, slackware, rapsbian, pidora
+- test: exherbo, alpine, slackware, rapsbian, pidora
 - smartos, omnios, openindiana, opensolaris, nexentacore?
 
 ## License & Authors

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,11 +8,9 @@ version          "0.4.2"
 source_url       "https://github.com/lamont-cookbooks/chef_hostname"
 issues_url       "https://github.com/lamont-cookbooks/chef_hostname/issues"
 
-depends "compat_resource"
+chef_version ">= 12.5" if respond_to?(:chef_version)
 
-chef_version "~> 12.1" if respond_to?(:chef_version)
-
-%w{redhat centos scientific oracle fedora ubuntu debian linuxmint suse opensuse freebsd netbsd mac_os_x
+%w{redhat centos scientific oracle fedora ubuntu debian linuxmint suse opensuse opensuseleap freebsd netbsd mac_os_x
    solaris gentoo arch nexus}.each do |platform|
   supports platform
 end

--- a/test/fixtures/cookbooks/unit/metadata.rb
+++ b/test/fixtures/cookbooks/unit/metadata.rb
@@ -7,4 +7,3 @@ long_description "Installs/Configures unit"
 version "0.1.0"
 
 depends "chef_hostname"
-depends "compat_resource"


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>