### PR TITLE
add default recipe to set hostname to node.node

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ end
 
 ## Notes
 
-There are no recipes in this cookbook, the resource is meant to be used in your own custom recipes. There are no attributes in this cookbook, you can drive the resource off of whatever attribute(s) you like.
+The default recipe in this cookbook simply sets hostname to node.name as found in chef-server, the resource is meant to be used in your own custom recipes. There are no attributes in this cookbook, you can drive the resource off of whatever attribute(s) you like.
 
 Docker container hostnames do not persist after restarts due to limitations of docker.
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,21 @@
+#
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Cookbook:: chef_hostname
+# Recipe:: default
+#
+# Copyright:: 2016-2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+hostname node.name


### PR DESCRIPTION
Signed-off-by: Corey Hemminger <corey.hemminger@nativex.com>

### Description

Creates default recipe to simply set hostname to node.name for those that only need this one simple function

### Issues Resolved

NA

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
