### PR TITLE
added cookbook property to cookbook_file resource (fixing issue #32)

### DIFF
--- a/resources/hostname.rb
+++ b/resources/hostname.rb
@@ -172,6 +172,7 @@ action :set do
     ec2_config_xml = 'C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml'
     cookbook_file ec2_config_xml do
       source "config.xml"
+      cookbook "chef_hostname"
       only_if { ::File.exist? ec2_config_xml }
     end
 


### PR DESCRIPTION
Signed-off-by: Bernhard Ott <bernhard.ott@westernacher.com>

### Description
This is a quick fix for the failing coobook_file resource on windows (see linked issue).

### Issues Resolved

custom resource fails on windows because of looking for cookbook_file source in wrapper cookbook context (https://github.com/chef-cookbooks/chef_hostname/issues/32)

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

