### PR TITLE
fixed rebooting windows on every chef_run (issue #33)

### DIFF
--- a/resources/hostname.rb
+++ b/resources/hostname.rb
@@ -181,13 +181,14 @@ action :set do
         $sysInfo = Get-WmiObject -Class Win32_ComputerSystem
         $sysInfo.Rename("#{new_resource.hostname}")
       EOH
+      notifies :request_reboot, 'reboot[setting hostname]'
       not_if { Socket.gethostbyname(Socket.gethostname).first == new_resource.hostname }
     end
 
     # reboot because $windows
     reboot "setting hostname" do
       reason "chef setting hostname"
-      action :request_reboot
+      action :nothing
       only_if { new_resource.windows_reboot }
     end
   end


### PR DESCRIPTION
### Description
This is a quick fix for the non-idempotent `reboot` resource on windows (see linked issue).

### Issues Resolved

hostname resource *always* reboots windows hosts  (https://github.com/chef-cookbooks/chef_hostname/issues/33)

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
