### PR TITLE
Update hostname resource check

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,7 +20,7 @@ platforms:
   - name: fedora-26
   - name: freebsd-10
   - name: freebsd-11
-  - name: opensuse-leap-42
+  - name: opensuse-leap-42.2
   - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: windows-2008r2

--- a/resources/hostname.rb
+++ b/resources/hostname.rb
@@ -95,7 +95,7 @@ action :set do
           group node["root_group"]
           mode "0644"
         end
-      when ::File.exist?("/etc/sysconfig/network")
+      when ::File.file?("/etc/sysconfig/network")
         # older non-systemd RHEL/Fedora derived
         append_replacing_matching_lines("/etc/sysconfig/network", /^HOSTNAME\s*=/, "HOSTNAME=#{new_resource.hostname}")
       when ::File.exist?("/etc/HOSTNAME")


### PR DESCRIPTION

### Description

Update hostname resource check for File check so that on SUSE systems the directory `/etc/sysconfig/network` doesn't cause failures.

### Issues Resolved

#41 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
